### PR TITLE
feat: add ANSI escape code support to output pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "play.flix.dev",
       "version": "1.0.0",
       "dependencies": {
+        "ansi-to-react": "^6.2.6",
         "bootstrap": "^5.3.2",
         "lz-string": "^1.5.0",
         "pretty-ms": "^8.0.0",
@@ -1441,6 +1442,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1465,6 +1472,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-to-react": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/ansi-to-react/-/ansi-to-react-6.2.6.tgz",
+      "integrity": "sha512-Eqi0iaMK5OZ3jsVFxWvU2B74UZBnGuHlkflKMX6wTOeH+luy9KE2O0gUkc2PxhIP1R4IO0xohv62UMFInQOSeg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "anser": "^2.3.2",
+        "escape-carriage": "^1.3.1",
+        "linkify-it": "^3.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/argparse": {
@@ -2276,6 +2298,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3538,6 +3566,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
       }
     },
     "node_modules/locate-path": {
@@ -4890,6 +4927,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "ansi-to-react": "^6.2.6",
     "bootstrap": "^5.3.2",
     "lz-string": "^1.5.0",
     "pretty-ms": "^8.0.0",

--- a/src/RightPane.jsx
+++ b/src/RightPane.jsx
@@ -7,7 +7,9 @@ export default function RightPane({ result, version, compilationTime, evaluation
     if (result !== undefined) {
       return (
         <code>
-          <pre><Ansi>{result}</Ansi></pre>
+          <pre>
+            <Ansi>{result}</Ansi>
+          </pre>
         </code>
       )
     } else {

--- a/src/RightPane.jsx
+++ b/src/RightPane.jsx
@@ -1,3 +1,4 @@
+import Ansi from 'ansi-to-react'
 import GridLoader from 'react-spinners/GridLoader'
 import prettyms from 'pretty-ms'
 
@@ -6,7 +7,7 @@ export default function RightPane({ result, version, compilationTime, evaluation
     if (result !== undefined) {
       return (
         <code>
-          <pre>{result}</pre>
+          <pre><Ansi>{result}</Ansi></pre>
         </code>
       )
     } else {


### PR DESCRIPTION
## Summary
- Add `ansi-to-react` dependency to parse ANSI escape codes in program output
- Wrap output text in `<Ansi>` component in `RightPane.jsx` so colored compiler messages (errors, warnings) render with proper styling instead of showing raw escape sequences
- Plain text without ANSI codes renders identically to before

## Test plan
- [x] `npm run dev` and run a program with normal output — should render unchanged
- [x] Test with ANSI codes (e.g. colored error/warning messages from the backend) — colors should render correctly
- [x] Verify responsive layout still works at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)