### PR TITLE
feat: group examples dropdown by category

### DIFF
--- a/build-scripts/fetchExamples.mjs
+++ b/build-scripts/fetchExamples.mjs
@@ -14,6 +14,7 @@ export async function fetchSampleFiles() {
     .filter(
       entry =>
         entry.path.startsWith('examples/') &&
+        !entry.path.startsWith('examples/unsorted/') &&
         entry.type === 'blob' &&
         entry.path.endsWith('.flix') &&
         !projectDirs.some(dir => entry.path.startsWith(dir)),

--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -28,6 +28,25 @@ export default function Menu({ connected, notifyRun, notifySampleChange, url }) 
   }
 
   function getDropDown() {
+    const groups = new Map()
+    SamplesData.forEach((sample, index) => {
+      const slashIndex = sample.name.indexOf('/')
+      const group = slashIndex !== -1 ? sample.name.slice(0, slashIndex) : ''
+      const displayName = slashIndex !== -1 ? sample.name.slice(slashIndex + 1) : sample.name
+      if (!groups.has(group)) {
+        groups.set(group, [])
+      }
+      groups.get(group).push({ index, displayName })
+    })
+
+    function formatGroupLabel(key) {
+      if (!key) return 'Other'
+      return key
+        .split('-')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+    }
+
     return (
       <select
         defaultValue={'placeholder'}
@@ -40,10 +59,14 @@ export default function Menu({ connected, notifyRun, notifySampleChange, url }) 
           -- select example --
         </option>
 
-        {SamplesData.map((sample, index) => (
-          <option key={index} value={index}>
-            {sample.name}
-          </option>
+        {[...groups.entries()].map(([group, samples]) => (
+          <optgroup key={group} label={formatGroupLabel(group)}>
+            {samples.map(({ index, displayName }) => (
+              <option key={index} value={index}>
+                {displayName}
+              </option>
+            ))}
+          </optgroup>
         ))}
       </select>
     )


### PR DESCRIPTION
## Summary
- Group the examples dropdown using native `<optgroup>` headers derived from top-level folder names (e.g., "Concurrency And Parallelism", "Datalog", "Effects And Handlers")
- Exclude samples from the `unsorted` category during build-time fetching
- Display only the relative filename within each group instead of the full path

## Test plan
- [x] Run `npm run generate` and verify `Samples.js` contains no `unsorted/` entries
- [x] Open the app and verify the dropdown shows grouped categories with bold headers
- [x] Verify selecting a sample from any group still loads the correct code

🤖 Generated with [Claude Code](https://claude.com/claude-code)