### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,14 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.setAttribute('data-bs-theme', theme);
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script>
-      (function() {
-        var stored = localStorage.getItem('theme');
-        var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-        document.documentElement.setAttribute('data-theme', theme);
-        document.documentElement.setAttribute('data-bs-theme', theme);
-      })();
+      ;(function () {
+        var stored = localStorage.getItem('theme')
+        var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        document.documentElement.setAttribute('data-theme', theme)
+        document.documentElement.setAttribute('data-bs-theme', theme)
+      })()
     </script>
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>

--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@
   --gutter-text: #b4b4b4;
 }
 
-[data-theme="dark"] {
+[data-theme='dark'] {
   --bg-body: #1a1a1a;
   --bg-left-pane: #1d1f21;
   --bg-right-pane: #212121;
@@ -20,19 +20,19 @@
   --gutter-text: #555555;
 }
 
-[data-theme="dark"] select {
+[data-theme='dark'] select {
   background-color: var(--bg-left-pane);
   color: var(--text-code);
   border-color: var(--border-color);
 }
 
-[data-theme="dark"] .btn-light {
+[data-theme='dark'] .btn-light {
   background-color: #333333;
   border-color: #444444;
   color: #e0e0e0;
 }
 
-[data-theme="dark"] .btn-light:hover {
+[data-theme='dark'] .btn-light:hover {
   background-color: #444444;
   border-color: #555555;
   color: #ffffff;

--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,52 @@
+:root {
+  --bg-body: #e1e1db;
+  --bg-left-pane: #fafafa;
+  --bg-right-pane: #fffffa;
+  --border-color: #b4b4b4;
+  --text-code: #111111;
+  --text-muted: gray;
+  --active-line: #ffffcc;
+  --gutter-text: #b4b4b4;
+}
+
+[data-theme="dark"] {
+  --bg-body: #1a1a1a;
+  --bg-left-pane: #1d1f21;
+  --bg-right-pane: #212121;
+  --border-color: #444444;
+  --text-code: #e0e0e0;
+  --text-muted: #999999;
+  --active-line: #2a2a2a;
+  --gutter-text: #555555;
+}
+
+[data-theme="dark"] select {
+  background-color: var(--bg-left-pane);
+  color: var(--text-code);
+  border-color: var(--border-color);
+}
+
+[data-theme="dark"] .btn-light {
+  background-color: #333333;
+  border-color: #444444;
+  color: #e0e0e0;
+}
+
+[data-theme="dark"] .btn-light:hover {
+  background-color: #444444;
+  border-color: #555555;
+  color: #ffffff;
+}
+
 body {
-  background-color: #e1e1db;
+  background-color: var(--bg-body);
   font-family: 'Open Sans', sans-serif;
 }
 
 code {
   font-family: 'Source Code Pro', monospace;
   font-size: 0.9rem;
-  color: #111111;
+  color: var(--text-code);
 }
 
 .menu {
@@ -39,8 +79,8 @@ code {
 }
 
 .left-pane {
-  background-color: #fafafa;
-  border: 4px solid #b4b4b4;
+  background-color: var(--bg-left-pane);
+  border: 4px solid var(--border-color);
   border-radius: 4px;
 
   width: 50%;
@@ -53,8 +93,8 @@ code {
   flex-direction: column;
   justify-content: space-between;
 
-  background-color: #fffffa;
-  border: 1px solid #b4b4b4;
+  background-color: var(--bg-right-pane);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
 
   width: 50%;
@@ -93,29 +133,29 @@ code {
 }
 
 .statistics {
-  color: gray;
+  color: var(--text-muted);
   font-size: 0.8rem;
   text-align: right;
 
-  border-top: 1px solid #b4b4b4;
+  border-top: 1px solid var(--border-color);
   padding-top: 0.3rem;
 }
 
 h3 {
   text-align: center;
   font-size: 1.1rem;
-  color: gray;
+  color: var(--text-muted);
 
-  border-bottom: 1px solid #b4b4b4;
+  border-bottom: 1px solid var(--border-color);
   padding-bottom: 0.3rem;
 
   margin-bottom: 1rem;
 }
 
 .ace_marker-layer .ace_active-line {
-  background-color: #ffffcc !important;
+  background-color: var(--active-line) !important;
 }
 
 .ace_gutter-cell {
-  color: #b4b4b4;
+  color: var(--gutter-text);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -164,7 +164,14 @@ export default function App() {
 
   return (
     <div>
-      <Menu connected={connected} notifyRun={notifyRun} notifySampleChange={notifyOnChange} program={program} isDark={isDark} toggleDarkMode={toggleDarkMode} />
+      <Menu
+        connected={connected}
+        notifyRun={notifyRun}
+        notifySampleChange={notifyOnChange}
+        program={program}
+        isDark={isDark}
+        toggleDarkMode={toggleDarkMode}
+      />
       <div className="page">
         <LeftPane initial={program} notifyOnChange={notifyOnChange} isDark={isDark} />
         <RightPane

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,12 @@ def main(): Unit \\\\ IO =
     println(area(Shape.Rectangle(2, 4)))
 `
 
+function getInitialTheme() {
+  const stored = localStorage.getItem('theme')
+  if (stored) return stored === 'dark'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
 export default function App() {
   const [connected, setConnected] = useState(undefined)
   const [program, setProgram] = useState(null)
@@ -38,6 +44,7 @@ export default function App() {
   const [version, setVersion] = useState(undefined)
   const [compilationTime, setCompilationTime] = useState(undefined)
   const [evaluationTime, setEvaluationTime] = useState(undefined)
+  const [isDark, setIsDark] = useState(getInitialTheme)
 
   const websocket = useRef(null)
   const programRef = useRef(program)
@@ -46,6 +53,17 @@ export default function App() {
   // Keep refs in sync with state
   programRef.current = program
   connectedRef.current = connected
+
+  useEffect(() => {
+    const theme = isDark ? 'dark' : 'light'
+    document.documentElement.setAttribute('data-theme', theme)
+    document.documentElement.setAttribute('data-bs-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [isDark])
+
+  const toggleDarkMode = useCallback(() => {
+    setIsDark(prev => !prev)
+  }, [])
 
   // Load initial program (async for URL decompression)
   useEffect(() => {
@@ -146,14 +164,15 @@ export default function App() {
 
   return (
     <div>
-      <Menu connected={connected} notifyRun={notifyRun} notifySampleChange={notifyOnChange} program={program} />
+      <Menu connected={connected} notifyRun={notifyRun} notifySampleChange={notifyOnChange} program={program} isDark={isDark} toggleDarkMode={toggleDarkMode} />
       <div className="page">
-        <LeftPane initial={program} notifyOnChange={notifyOnChange} />
+        <LeftPane initial={program} notifyOnChange={notifyOnChange} isDark={isDark} />
         <RightPane
           result={result}
           version={version}
           compilationTime={compilationTime}
           evaluationTime={evaluationTime}
+          isDark={isDark}
         />
       </div>
     </div>

--- a/src/Editor.jsx
+++ b/src/Editor.jsx
@@ -2,15 +2,16 @@ import AceEditor from 'react-ace'
 
 import 'ace-builds/src-noconflict/mode-flix'
 import 'ace-builds/src-noconflict/theme-xcode'
+import 'ace-builds/src-noconflict/theme-tomorrow_night'
 
-export default function Editor({ code, notifyOnChange }) {
+export default function Editor({ code, notifyOnChange, isDark }) {
   return (
     <div>
       <div>
         <div>
           <AceEditor
             mode="flix"
-            theme="xcode"
+            theme={isDark ? 'tomorrow_night' : 'xcode'}
             fontSize={14}
             showGutter={true}
             showPrintMargin={true}

--- a/src/LeftPane.jsx
+++ b/src/LeftPane.jsx
@@ -1,9 +1,9 @@
 import Editor from './Editor'
 
-export default function LeftPane({ initial, notifyOnChange }) {
+export default function LeftPane({ initial, notifyOnChange, isDark }) {
   return (
     <div className="left-pane">
-      <Editor code={initial} notifyOnChange={notifyOnChange} />
+      <Editor code={initial} notifyOnChange={notifyOnChange} isDark={isDark} />
     </div>
   )
 }

--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -3,7 +3,7 @@ import { Button, Form } from 'reactstrap'
 import SamplesData from './data/Samples'
 import { compressToURL } from './compression'
 
-export default function Menu({ connected, notifyRun, notifySampleChange, program }) {
+export default function Menu({ connected, notifyRun, notifySampleChange, program, isDark, toggleDarkMode }) {
   const [choice, setChoice] = useState(undefined)
 
   function getRunButton() {
@@ -112,6 +112,15 @@ export default function Menu({ connected, notifyRun, notifySampleChange, program
 
         <Button color="light" className="ml-3" onClick={updateLinkUrl}>
           Shareable Link <i className="fa fa-clipboard ml-2" />
+        </Button>
+
+        <Button
+          color="light"
+          onClick={toggleDarkMode}
+          style={{ width: '38px', height: '38px', padding: 0, marginLeft: '0.5rem' }}
+          title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          <i className={isDark ? 'fa fa-sun-o' : 'fa fa-moon-o'} />
         </Button>
       </div>
     </div>

--- a/src/RightPane.jsx
+++ b/src/RightPane.jsx
@@ -2,7 +2,7 @@ import Ansi from 'ansi-to-react'
 import GridLoader from 'react-spinners/GridLoader'
 import prettyms from 'pretty-ms'
 
-export default function RightPane({ result, version, compilationTime, evaluationTime }) {
+export default function RightPane({ result, version, compilationTime, evaluationTime, isDark }) {
   function getResult() {
     if (result !== undefined) {
       return (
@@ -15,7 +15,7 @@ export default function RightPane({ result, version, compilationTime, evaluation
     } else {
       return (
         <div className="spinner">
-          <GridLoader sizeUnit={'px'} size={50} color={'#28a745'} loading={true} />
+          <GridLoader sizeUnit={'px'} size={50} color={isDark ? '#4caf80' : '#28a745'} loading={true} />
         </div>
       )
     }


### PR DESCRIPTION
## Summary
- Adds a dark mode toggle button (moon/sun icon) next to the "Shareable Link" button in the menu bar
- Uses CSS custom properties for all colors with `[data-theme="dark"]` overrides
- Persists theme preference to localStorage; auto-detects system `prefers-color-scheme` on first visit
- Inline script in `index.html` prevents flash of wrong theme on load
- Ace editor switches between `xcode` (light) and `tomorrow_night` (dark) themes
- Bootstrap `btn-light` buttons get dark overrides; `data-bs-theme` attribute set for other Bootstrap components

## Test plan
- [x] Click the moon/sun toggle — UI switches between light and dark themes
- [x] Refresh the page — theme preference persists
- [x] Clear localStorage `theme` key, set OS to dark mode, refresh — should default to dark
- [x] Ace editor switches between `xcode` and `tomorrow_night` themes
- [x] Bootstrap buttons (Run, Shareable Link, links) adapt in both themes
- [x] Output pane text and spinner are visible in both themes
- [x] On screens ≤ 450px, toggle is hidden (matches existing menu bar behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)